### PR TITLE
[CHORE] SSH 없이 EC2 자체 호스팅 러너에서 배포 스크립트 실행하도록 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,15 +15,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Add SSH key
-        uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
-
-      - name: Deploy to EC2
+      - name: Deploy directly on self-hosted EC2
         run: |
-          ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} << 'EOF'
-            cd ~/app/step1
-            chmod +x deploy.sh
-            ./deploy.sh
-          EOF
+          cd ~/app/step1
+          chmod +x deploy.sh
+          ./deploy.sh


### PR DESCRIPTION
## 📝작업 내용

> SSH 포트를 열지 않기 위해 EC2에 자체 호스팅 러너를 설치하고, 러너 내에서 자동으로 배포 스크립트를 실행하도록 워크플로우를 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

