### PR TITLE
[FIX] CodeDeploy 액션 사용 불가로 AWS CLI 직접 호출 방식으로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,17 +48,15 @@ jobs:
           AWS_REGION: ap-northeast-2
           SOURCE_DIR: deploy
 
-      - name: Deploy to AWS CodeDeploy
-        uses: aws-actions/aws-codedeploy-github-deploy@v1
-        with:
-          application-name: ${{ secrets.CODEDEPLOY_APP_NAME }}
-          deployment-group: ${{ secrets.CODEDEPLOY_DEPLOY_GROUP }}
-          deployment-config-name: CodeDeployDefault.AllAtOnce
-          deployment-description: "Deploy from GitHub Actions"
-          bucket: ${{ secrets.AWS_S3_BUCKET }}
-          key: cotato-11th-weather.zip
-          region: ap-northeast-2
-          wait-for-deployment-status: true
+      - name: Deploy to AWS CodeDeploy using AWS CLI
+        run: |
+          aws deploy create-deployment \
+            --application-name ${{ secrets.CODEDEPLOY_APP_NAME }}
+            --deployment-group-name ${{ secrets.CODEDEPLOY_DEPLOY_GROUP }} \
+            --deployment-config-name CodeDeployDefault.AllAtOnce \
+            --description "Deploy from GitHub Actions via AWS CLI" \
+            --s3-location bucket=${{ secrets.AWS_S3_BUCKET }},bundleType=zip,key=cotato-11th-weather.zip \
+            --region ap-northeast-2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## 📝작업 내용

> aws-actions/aws-codedeploy-github-deploy 액션이 삭제되어 더 이상 사용 불가
GitHub Actions에서 AWS CLI를 직접 호출하는 방식으로 CodeDeploy 배포 방식 전환

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
