### PR TITLE
[FIX] appspec.yml 파일 수정

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -6,13 +6,13 @@ files:
     overwrite: yes
 
 permissions:
-  -object: /
-  pattern : "**"
-  owner: ec2-user
-  group: ec2-user
+  - object: /home/ec2-user/app/step2/zip
+    pattern: "**"
+    owner: ec2-user
+    group: ec2-user
 
 hooks:
-  ApplicationStart:
+  BeforeInstall:
     - location: deploy.sh
       timeout: 60
       runas: ec2-user


### PR DESCRIPTION
## 📝작업 내용

> appspec.yml의 hooks 설정을 ApplicationStart ➝ BeforeInstall로 변경
- permissions 설정에서 오타(-object: ➝ - object:) 수정
- 기존 배포가 BeforeInstall 단계에서 실패하거나 무한 대기 상태였던 이슈를 해결하기 위함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

