### PR TITLE
[FIX] Spring Boot에서 DB 연결 환경 변수 인식 안 되는 문제 수정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -30,7 +30,7 @@ echo "> 실행 권한 부여: $JAR_NAME"
 chmod +x $JAR_NAME
 
 echo "> 애플리케이션 실행"
-nohup java -jar \
+nohup RDS_URL=$RDS_URL RDS_USERNAME=$RDS_USERNAME RDS_PASSWORD=$RDS_PASSWORD java -jar \
   -Dspring.config.location=file:$APP_DIR/application-prod.yml \
   -Dspring.profiles.active=prod \
   $JAR_NAME > $APP_DIR/applications.log 2>&1 &


### PR DESCRIPTION
## 📝작업 내용

> .env에서 불러온 RDS_URL, RDS_USERNAME, RDS_PASSWORD가 Spring Boot 프로세스에 전달되지 않아 JDBC URL 오류가 발생
- deploy.sh에서 java 실행 시 명시적으로 환경 변수를 넘겨주도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
