### PR TITLE
[BUGFIX] OpenWeatherMap API 호출 시 위도와 경도 순서 수정

### DIFF
--- a/src/main/java/com/cotato/weather/domain/place/service/OpenWeatherMapService.java
+++ b/src/main/java/com/cotato/weather/domain/place/service/OpenWeatherMapService.java
@@ -81,12 +81,12 @@ public class OpenWeatherMapService {
     }
 
     public ApiStatus checkApiStatus() {
-        Long testPlaceId = 1L; // 테스트용으로 사용할 장소 ID
+        Long testPlaceId = 2L; // 테스트용으로 사용할 장소 ID
 
         SavedPlace savedPlace = placeService.getSavedPlace(testPlaceId);
 
         String weatherUrl = buildUrl(openWeatherMapApiConfig.getWeatherUrl(),
-                openWeatherMapApiConfig.getApiKey(), savedPlace.getX(), savedPlace.getY());
+                openWeatherMapApiConfig.getApiKey(), savedPlace.getY(), savedPlace.getX());
 
         String weatherResponse = null;
 


### PR DESCRIPTION
## 📝작업 내용

> OpenWeatherMap API 요청 시 lat, lon 파라미터의 순서가 잘못되어 400 Bad Request 발생
- savedPlace.getX(), savedPlace.getY() → savedPlace.getY(), savedPlace.getX()로 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
