### PR TITLE
[FIX] S3 업로드 경로와 CodeDeploy key 불일치 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,15 +50,11 @@ jobs:
           zip -r ../deploy/cotato-11th-weather.zip .
 
       - name: Upload to S3
-        uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl private --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        run: |
+          aws s3 cp deploy/cotato-11th-weather.zip s3://${{ secrets.AWS_S3_BUCKET }}/cotato-11th-weather.zip --region ap-northeast-2
+          env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ap-northeast-2
-          SOURCE_DIR: deploy
 
       - name: Deploy to AWS CodeDeploy using AWS CLI
         run: |
@@ -67,7 +63,7 @@ jobs:
             --deployment-group-name ${{ secrets.CODEDEPLOY_DEPLOY_GROUP }} \
             --deployment-config-name CodeDeployDefault.AllAtOnce \
             --description "Deploy from GitHub Actions via AWS CLI" \
-            --s3-location bucket=${{ secrets.AWS_S3_BUCKET }},bundleType=zip,key=deploy/cotato-11th-weather.zip \
+            --s3-location bucket=${{ secrets.AWS_S3_BUCKET }},bundleType=zip,key=cotato-11th-weather.zip \
             --region ap-northeast-2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## 📝작업 내용

> - S3에 zip을 루트에 업로드하도록 aws s3 cp 사용
- key=deploy/... 설정 제거하여 경로 불일치 문제 수정
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
