### PR TITLE
[FIX] 날씨 API 호출시 위도/경도 순서 수정

### DIFF
--- a/src/main/java/com/cotato/weather/domain/place/service/OpenWeatherMapService.java
+++ b/src/main/java/com/cotato/weather/domain/place/service/OpenWeatherMapService.java
@@ -38,7 +38,7 @@ public class OpenWeatherMapService {
         SavedPlace savedPlace = placeService.getSavedPlace(placeId);
 
         String weatherUrl = buildUrl(openWeatherMapApiConfig.getWeatherUrl(),
-                openWeatherMapApiConfig.getApiKey(), savedPlace.getX(), savedPlace.getY());
+                openWeatherMapApiConfig.getApiKey(), savedPlace.getY(), savedPlace.getX());
 
         String weatherResponse = null;
         try {
@@ -54,7 +54,7 @@ public class OpenWeatherMapService {
         }
 
         String airPollutionUrl = buildUrl(openWeatherMapApiConfig.getAirPollutionUrl(),
-                openWeatherMapApiConfig.getApiKey(), savedPlace.getX(), savedPlace.getY());
+                openWeatherMapApiConfig.getApiKey(), savedPlace.getY(), savedPlace.getX());
 
         String airPollutionApiResponse = null;
         try {
@@ -103,7 +103,7 @@ public class OpenWeatherMapService {
         }
 
         String airPollutionUrl = buildUrl(openWeatherMapApiConfig.getAirPollutionUrl(),
-                openWeatherMapApiConfig.getApiKey(), savedPlace.getX(), savedPlace.getY());
+                openWeatherMapApiConfig.getApiKey(), savedPlace.getY(), savedPlace.getX());
 
         String airPollutionResponse = null;
         try {
@@ -264,7 +264,7 @@ public class OpenWeatherMapService {
         SavedPlace savedPlace = placeService.getSavedPlace(placeId);
 
         String weatherUrl = buildUrl(openWeatherMapApiConfig.getWeatherUrl(),
-                openWeatherMapApiConfig.getApiKey(), savedPlace.getX(), savedPlace.getY());
+                openWeatherMapApiConfig.getApiKey(), savedPlace.getY(), savedPlace.getX());
 
         String weatherResponse = null;
         try {
@@ -280,7 +280,7 @@ public class OpenWeatherMapService {
         }
 
         String airPollutionUrl = buildUrl(openWeatherMapApiConfig.getAirPollutionUrl(),
-                openWeatherMapApiConfig.getApiKey(), savedPlace.getX(), savedPlace.getY());
+                openWeatherMapApiConfig.getApiKey(), savedPlace.getY(), savedPlace.getX());
 
         String airPollutionApiResponse = null;
         try {


### PR DESCRIPTION
## 📝작업 내용

> buildUrl() 호출 시 savedPlace.getX()와 getY() 순서를 수정
> - 기존에는 위도/경도가 뒤바뀌어 OpenWeatherMap API에 잘못된 요청이 보내졌고, 이에 따라 400 Bad Request가 발생


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
