### PR TITLE
[CHORE] 블루-그린 무중단 배포 구현

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -2,7 +2,7 @@ version: 0.0
 os: linux
 files:
   - source: .
-    destination: /home/ec2-user/app/step2/zip/
+    destination: /home/ec2-user/app/step3/zip/
     overwrite: yes
 
 permissions:
@@ -17,6 +17,15 @@ hooks:
       timeout: 60
       runas: ec2-user
   AfterInstall:
-    - location: deploy.sh
+    - location: stop.sh
       timeout: 60
       runas: ec2-user
+  ApplicationStart:
+    - location: start.sh
+      timeout: 60
+      runas: ec2-user
+  ValidateService:
+    - location: health.sh
+      timeout: 60
+      runas: ec2-user
+

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.cotato'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.1-SNAPSHOT-' +new Date().format("yyyyMMddHHmmss")
 
 java {
 	toolchain {

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+source ${ABSDIR}/switch.sh
+
+IDLE_PORT=$(find_idle_port)
+
+echo "> Health Check Start!"
+echo "> IDLE_PORT: $IDLE_PORT"
+echo "> curl -s http://localhost:$IDLE_PORT/profile "
+sleep 10
+
+for RETRY_COUNT in {1..10}
+do
+  RESPONSE=$(curl -s http://localhost:${IDLE_PORT}/profile)
+  UP_COUNT=$(echo ${RESPONSE} | grep 'prod' | wc -l)
+
+  if [ ${UP_COUNT} -ge 1 ]
+  then # $up_count >= 1 ("prod" 문자열이 있는지 검증)
+    echo "> Health check 성공"
+    switch_proxy
+    break
+  else
+    echo "> Health check의 응답을 알 수 없거나 혹은 실행 상태가 아닙니다."
+    echo "> Health check: ${RESPONSE}"
+  fi
+
+  if [ ${RETRY_COUNT} -eq 10 ]
+  then
+    echo "> Health check 실패"
+    echo "> 엔진엑스에 연결하지 않고 배포를 종료합니다."
+    exit 1
+  fi
+
+  echo "> Health check 연결 실패. 재시도..."
+  sleep 10
+done

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# 쉬고 있는 profile 찾기: prod1이 사용 중이면 prod2가 쉬고 있고, 반대면 prod1이 쉬고 있음
+function find_idle_profile() {
+    RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/profile)
+
+    if [ ${RESPONSE_CODE} -ge 400 ] #400 보다 크면(즉, 40x/50x 에러 모두 포함)
+    then
+      CURRENT_PROFILE=prod2
+    else
+      CURRENT_PROFILE=$(curl -s http://localhost/profile)
+    fi
+
+    if [ ${CURRENT_PROFILE} == prod1 ]
+    then
+      IDLE_PROFILE=prod2
+    else
+      IDLE_PROFILE=prod1
+    fi
+
+    echo "${IDLE_PROFILE}"
+}
+# 쉬고 있는 profile의 port 찾기
+function find_idle_port() {
+  IDLE_PROFILE=$(find_idle_profile)
+
+  if [ ${IDLE_PROFILE} == prod1 ]
+  then
+    echo "8081"
+  else
+    echo "8082"
+  fi
+}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+
+REPOSITORY=/home/ec2-user/app/step3
+PROJECT_NAME=11th-BE-Networking-May
+
+echo "> Build 파일 복사"
+echo "> cp $REPOSITORY/zip/*.jar $REPOSITORY/"
+
+cp $REPOSITORY/zip/*.jar $REPOSITORY/
+
+echo "> 새 애플리케이션 배포"
+JAR_NAME=$(ls -tr $REPOSITORY/*.jar | grep -v 'plain' | tail -n 1)
+
+echo "> JAR Name: $JAR_NAME"
+
+echo "> $JAR_NAME 에 실행권한 추가"
+
+chmod +x $JAR_NAME
+
+echo "> $JAR_NAME 실행"
+
+IDLE_PROFILE=$(find_idle_profile)
+
+echo "> $JAR_NAME 를 profile=$IDLE_PROFILE 로 실행합니다."
+nohup java -jar \
+    -Dspring.config.location=file:$REPOSITORY/application-$IDLE_PROFILE.yml \
+    -Dspring.profiles.active=$IDLE_PROFILE \
+    $JAR_NAME > $REPOSITORY/nohup.out 2>&1 &

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+
+IDLE_PORT=$(find_idle_port)
+
+echo "> $IDLE_PORT 에서 구동 중인 애플리케이션 pid 확인"
+IDLE_PID=$(lsof -ti tcp:${IDLE_PORT})
+
+if [ -z ${IDLE_PID} ]
+then
+  echo "> 현재 구동 중인 애플리케이션이 없으므로 종료하지 않습니다."
+else
+  echo "> kill -15 $IDLE_PID"
+  kill -15 ${IDLE_PID}
+  sleep 5
+fi

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+ABSPATH=$(readlink -f $0)
+ABSDIR=$(dirname $ABSPATH)
+source ${ABSDIR}/profile.sh
+
+function switch_proxy() {
+  IDLE_PORT=$(find_idle_port)
+
+  echo "> 전환할 Port: $IDLE_PORT"
+  echo "> Port 전환"
+  echo "set \$service_url http://127.0.0.1:${IDLE_PORT};" | sudo tee /etc/nginx/conf.d/service-url.inc
+
+  echo "> 엔진엑스 Reload"
+  sudo service nginx reload
+}


### PR DESCRIPTION
## 📝작업 내용

> Blue-Green 방식을 활용한 무중단 배포를 위해 EC2 인스턴스를 2개(prod1/prod2)로 운영

## 주요 변경사항
1. **프로필 조회 API 추가**  
   - `ProfileController` `/profile` 엔드포인트  
   - `find_idle_profile()`, `find_idle_port()` 로직 (`profile.sh`)

2. **배포 스크립트**  
   - `stop.sh`: 대기 포트 앱 종료  
   - `start.sh`: 대기 포트에 새 버전 앱 시작  
   - `health.sh`: 새 버전 헬스체크 → 성공 시 `switch.sh`로 Nginx 전환  
   - `switch.sh`: `/etc/nginx/conf.d/service-url.inc` 교체 + Nginx reload

3. **appspec.yml**  
   - `BeforeInstall`: `cleanup.sh`  
   - `AfterInstall`: `stop.sh`  
   - `ApplicationStart`: `start.sh`  
   - `ValidateService`: `health.sh`

4. **CI 패키징(deploy.yml)**  
   - `scripts/*.sh`, `appspec.yml`, `*.jar` 을 `before-deploy/` → ZIP 루트로 복사

5. **버전 관리(build.gradle)**  
   - `version = '1.0.1-SNAPSHOT-' + yyyyMMddHHmmss` → 타임스탬프 기반 배포 식별

 ## 배포 흐름
```plaintext
GitHub Actions
  └─(패키징)→ S3 저장
             └─(CLI 호출)→ CodeDeploy
                      ├─cleanup.sh
                      ├─stop.sh
                      ├─start.sh
                      └─health.sh → switch.sh → Nginx 프록시 전환
```
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
