### PR TITLE
[CHORE] switch.sh에 Nginx 실행 보장 로직 추가

### DIFF
--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -5,6 +5,12 @@ ABSDIR=$(dirname $ABSPATH)
 source ${ABSDIR}/profile.sh
 
 function switch_proxy() {
+  # Nginx 실행 보장
+  if ! systemctl is-active --quiet nginx; then
+    echo "> Nginx가 꺼져 있어서 시작합니다."
+    sudo systemctl start nginx
+  fi
+
   IDLE_PORT=$(find_idle_port)
 
   echo "> 전환할 Port: $IDLE_PORT"


### PR DESCRIPTION
## 📝작업 내용

> ValidateService 단계에서 Nginx가 아직 기동되지 않아 `systemctl reload nginx`가 실패
> - `switch.sh`의 `switch_proxy` 함수 시작 부분에 Nginx 실행 여부를 확인하는 로직을 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
